### PR TITLE
feat: Add in overwrite variable and pass through to the call to the ssm par…

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ No modules.
 | <a name="input_ignore_value_changes"></a> [ignore\_value\_changes](#input\_ignore\_value\_changes) | Whether to create SSM Parameter and ignore changes in value | `bool` | `false` | no |
 | <a name="input_key_id"></a> [key\_id](#input\_key\_id) | KMS key ID or ARN for encrypting a parameter (when type is SecureString) | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of SSM parameter | `string` | `null` | no |
+| <a name="input_overwrite"></a> [overwrite](#input\_overwrite) | Overwrite an existing parameter. If not specified, defaults to false during create operations to avoid overwriting existing resources and then true for all subsequent operations once the resource is managed by Terraform. Only relevant if ignore\_value\_changes is false. | `bool` | `false` | no |
 | <a name="input_secure_type"></a> [secure\_type](#input\_secure\_type) | Whether the type of the value should be considered as secure or not? | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to resources | `map(string)` | `{}` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are Standard, Advanced, and Intelligent-Tiering. Downgrading an Advanced tier parameter to Standard will recreate the resource. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,8 @@ resource "aws_ssm_parameter" "this" {
   allowed_pattern = var.allowed_pattern
   data_type       = var.data_type
 
+  overwrite = var.overwrite
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "overwrite" {
+  description = "Overwrite an existing parameter. If not specified, defaults to false during create operations to avoid overwriting existing resources and then true for all subsequent operations once the resource is managed by Terraform. Only relevant if ignore_value_changes is false."
+  type        = bool
+  default     = false
+}

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -10,6 +10,7 @@ module "wrapper" {
   ignore_value_changes = try(each.value.ignore_value_changes, var.defaults.ignore_value_changes, false)
   key_id               = try(each.value.key_id, var.defaults.key_id, null)
   name                 = try(each.value.name, var.defaults.name, null)
+  overwrite            = try(each.value.overwrite, var.defaults.overwrite, false)
   secure_type          = try(each.value.secure_type, var.defaults.secure_type, false)
   tags                 = try(each.value.tags, var.defaults.tags, {})
   tier                 = try(each.value.tier, var.defaults.tier, null)


### PR DESCRIPTION
…ameter resource that is not ignoring value changes

## Description

For context, I added an issue as well: https://github.com/terraform-aws-modules/terraform-aws-ssm-parameter/issues/10

Adding in support for passing through the `overwrite` attribute of the `aws_ssm_parameter` resource: https://registry.terraform.io/providers/hashicorp/aws/6.17.0/docs/resources/ssm_parameter#overwrite-14

## Motivation and Context
The `overwrite` attribute on the `aws_ssm_parameter` seems to remain as a non-deprecated attribute, so ensuring that this piece of the SSM parameter functionality can be utilized via this module.

## Breaking Changes
Assuming there aren't any actual versions of the AWS provider/AWS APIs where this was indeed removed from support from AWS apis, then I think it wouldn't be breaking?

## How Has This Been Tested?

I can go through some testing scenarios/add test cases if this is even the right move. Figured I'd start here w/ just proposing it basically and I will move forward w/ that if this looks like the right move.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
