### PR TITLE
feat!: Upgrade AWS provider and min required Terraform version to `6.8` and `1.11` respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ module "parameter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.37 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.37 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
@@ -199,6 +199,7 @@ No modules.
 | <a name="input_key_id"></a> [key\_id](#input\_key\_id) | KMS key ID or ARN for encrypting a parameter (when type is SecureString) | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of SSM parameter | `string` | `null` | no |
 | <a name="input_overwrite"></a> [overwrite](#input\_overwrite) | Overwrite an existing parameter. If not specified, defaults to false during create operations to avoid overwriting existing resources and then true for all subsequent operations once the resource is managed by Terraform. Only relevant if ignore\_value\_changes is false. | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration | `string` | `null` | no |
 | <a name="input_secure_type"></a> [secure\_type](#input\_secure\_type) | Whether the type of the value should be considered as secure or not? | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to resources | `map(string)` | `{}` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are Standard, Advanced, and Intelligent-Tiering. Downgrading an Advanced tier parameter to Standard will recreate the resource. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -167,14 +167,14 @@ module "parameter" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.8 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.8 |
 
 ## Modules
 
@@ -191,20 +191,21 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_pattern"></a> [allowed\_pattern](#input\_allowed\_pattern) | Regular expression used to validate the parameter value. | `string` | `null` | no |
+| <a name="input_allowed_pattern"></a> [allowed\_pattern](#input\_allowed\_pattern) | Regular expression used to validate the parameter value | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create SSM Parameter | `bool` | `true` | no |
-| <a name="input_data_type"></a> [data\_type](#input\_data\_type) | Data type of the parameter. Valid values: text, aws:ssm:integration and aws:ec2:image for AMI format. | `string` | `null` | no |
+| <a name="input_data_type"></a> [data\_type](#input\_data\_type) | Data type of the parameter. Valid values: `text`, `aws:ssm:integration` and `aws:ec2:image` for AMI format, see the [Native parameter support for Amazon Machine Image IDs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html) | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of the parameter | `string` | `null` | no |
 | <a name="input_ignore_value_changes"></a> [ignore\_value\_changes](#input\_ignore\_value\_changes) | Whether to create SSM Parameter and ignore changes in value | `bool` | `false` | no |
-| <a name="input_key_id"></a> [key\_id](#input\_key\_id) | KMS key ID or ARN for encrypting a parameter (when type is SecureString) | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name of SSM parameter | `string` | `null` | no |
-| <a name="input_overwrite"></a> [overwrite](#input\_overwrite) | Overwrite an existing parameter. If not specified, defaults to false during create operations to avoid overwriting existing resources and then true for all subsequent operations once the resource is managed by Terraform. Only relevant if ignore\_value\_changes is false. | `bool` | `false` | no |
+| <a name="input_key_id"></a> [key\_id](#input\_key\_id) | KMS key ID or ARN for encrypting a `SecureString` | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the parameter. If the name contains a path (e.g., any forward slashes (`/`)), it must be fully qualified with a leading forward slash (`/`) | `string` | `null` | no |
+| <a name="input_overwrite"></a> [overwrite](#input\_overwrite) | Overwrite an existing parameter. If not specified, defaults to `false` during create operations to avoid overwriting existing resources and then `true` for all subsequent operations once the resource is managed by Terraform | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration | `string` | `null` | no |
-| <a name="input_secure_type"></a> [secure\_type](#input\_secure\_type) | Whether the type of the value should be considered as secure or not? | `bool` | `false` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to resources | `map(string)` | `{}` | no |
-| <a name="input_tier"></a> [tier](#input\_tier) | Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are Standard, Advanced, and Intelligent-Tiering. Downgrading an Advanced tier parameter to Standard will recreate the resource. | `string` | `null` | no |
-| <a name="input_type"></a> [type](#input\_type) | Type of the parameter. Valid types are String, StringList and SecureString. | `string` | `null` | no |
+| <a name="input_secure_type"></a> [secure\_type](#input\_secure\_type) | Whether the type of the value should be considered as secure or not | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_tier"></a> [tier](#input\_tier) | Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are Standard, Advanced, and Intelligent-Tiering. Downgrading an Advanced tier parameter to Standard will recreate the resource | `string` | `null` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of the parameter. Valid types are `String`, `StringList` and `SecureString` | `string` | `null` | no |
 | <a name="input_value"></a> [value](#input\_value) | Value of the parameter | `string` | `null` | no |
+| <a name="input_value_wo_version"></a> [value\_wo\_version](#input\_value\_wo\_version) | Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of type. Additionally, write-only values are never stored to state. `value_wo_version` can be used to trigger an update and is required with this argument | `number` | `null` | no |
 | <a name="input_values"></a> [values](#input\_values) | List of values of the parameter (will be jsonencoded to store as string natively in SSM) | `list(string)` | `[]` | no |
 
 ## Outputs
@@ -217,7 +218,6 @@ No modules.
 | <a name="output_secure_value"></a> [secure\_value](#output\_secure\_value) | Secure value of the parameter |
 | <a name="output_ssm_parameter_arn"></a> [ssm\_parameter\_arn](#output\_ssm\_parameter\_arn) | The ARN of the parameter |
 | <a name="output_ssm_parameter_name"></a> [ssm\_parameter\_name](#output\_ssm\_parameter\_name) | Name of the parameter |
-| <a name="output_ssm_parameter_tags_all"></a> [ssm\_parameter\_tags\_all](#output\_ssm\_parameter\_tags\_all) | All tags used for the parameter |
 | <a name="output_ssm_parameter_type"></a> [ssm\_parameter\_type](#output\_ssm\_parameter\_type) | Type of the parameter |
 | <a name="output_ssm_parameter_version"></a> [ssm\_parameter\_version](#output\_ssm\_parameter\_version) | Version of the parameter |
 | <a name="output_value"></a> [value](#output\_value) | Parameter value after jsondecode(). Probably this is what you are looking for |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,19 +20,21 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.37 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.37 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
+| <a name="module_explicit_region"></a> [explicit\_region](#module\_explicit\_region) | ../../ | n/a |
+| <a name="module_explicit_region_ignore_value_changes"></a> [explicit\_region\_ignore\_value\_changes](#module\_explicit\_region\_ignore\_value\_changes) | ../../ | n/a |
 | <a name="module_multiple"></a> [multiple](#module\_multiple) | ../../ | n/a |
 | <a name="module_multiple_ignore_value_changes"></a> [multiple\_ignore\_value\_changes](#module\_multiple\_ignore\_value\_changes) | ../../ | n/a |
 | <a name="module_wrapper"></a> [wrapper](#module\_wrapper) | ../../wrappers | n/a |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -33,8 +33,6 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
-| <a name="module_explicit_region"></a> [explicit\_region](#module\_explicit\_region) | ../../ | n/a |
-| <a name="module_explicit_region_ignore_value_changes"></a> [explicit\_region\_ignore\_value\_changes](#module\_explicit\_region\_ignore\_value\_changes) | ../../ | n/a |
 | <a name="module_multiple"></a> [multiple](#module\_multiple) | ../../ | n/a |
 | <a name="module_multiple_ignore_value_changes"></a> [multiple\_ignore\_value\_changes](#module\_multiple\_ignore\_value\_changes) | ../../ | n/a |
 | <a name="module_wrapper"></a> [wrapper](#module\_wrapper) | ../../wrappers | n/a |
@@ -60,7 +58,6 @@ No inputs.
 | <a name="output_secure_value"></a> [secure\_value](#output\_secure\_value) | Secure value of the parameter |
 | <a name="output_ssm_parameter_arn"></a> [ssm\_parameter\_arn](#output\_ssm\_parameter\_arn) | The ARN of the parameter |
 | <a name="output_ssm_parameter_name"></a> [ssm\_parameter\_name](#output\_ssm\_parameter\_name) | Name of the parameter |
-| <a name="output_ssm_parameter_tags_all"></a> [ssm\_parameter\_tags\_all](#output\_ssm\_parameter\_tags\_all) | All tags used for the parameter |
 | <a name="output_ssm_parameter_type"></a> [ssm\_parameter\_type](#output\_ssm\_parameter\_type) | Type of the parameter |
 | <a name="output_ssm_parameter_version"></a> [ssm\_parameter\_version](#output\_ssm\_parameter\_version) | Version of the parameter |
 | <a name="output_value"></a> [value](#output\_value) | Parameter value after jsondecode(). Probably this is what you are looking for |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,14 +19,14 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.8 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.8 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,8 +3,9 @@ provider "aws" {
 }
 
 locals {
-  name   = "ex-${basename(path.cwd)}"
-  region = "eu-west-1"
+  name            = "ex-${basename(path.cwd)}"
+  region          = "eu-west-1"
+  explicit_region = "eu-west-2"
 
   tags = {
     Name       = local.name
@@ -152,6 +153,28 @@ module "multiple_ignore_value_changes" {
   tags = local.tags
 }
 
+module "explicit_region" {
+  source = "../../"
+
+  region = local.explicit_region
+  name   = "explicit-region"
+  value  = "test-value"
+
+  tags = local.tags
+}
+
+module "explicit_region_ignore_value_changes" {
+  source = "../../"
+
+  ignore_value_changes = true
+
+  region = local.explicit_region
+  name   = "explicit-region-ignore-value-changes"
+  value  = "test-value"
+
+  tags = local.tags
+}
+
 ##########
 # Wrapper
 ##########
@@ -193,6 +216,6 @@ data "aws_ami" "amazon_linux" {
 
   filter {
     name   = "name"
-    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+    values = ["amzn2-ami-*"]
   }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,20 +3,23 @@ provider "aws" {
 }
 
 locals {
-  name            = "ex-${basename(path.cwd)}"
-  region          = "eu-west-1"
-  explicit_region = "eu-west-2"
+  name   = "ex-${basename(path.cwd)}"
+  region = "eu-west-1"
 
   tags = {
     Name       = local.name
     Example    = "complete"
     Repository = "github.com/terraform-aws-modules/terraform-aws-ssm-parameter"
   }
+}
 
+################################################################################
+# SSM Parameter
+################################################################################
+
+locals {
   parameters = {
-    #########
     # String
-    #########
     "string_simple" = {
       value = "string_value123"
     }
@@ -31,9 +34,7 @@ locals {
       data_type = "aws:ec2:image"
     }
 
-    ###############
     # SecureString
-    ###############
     "secure" = {
       type        = "SecureString"
       value       = "secret123123!!!"
@@ -67,9 +68,7 @@ locals {
       })
     }
 
-    #############
     # StringList
-    #############
     "list_as_autoguess_type" = {
       # List values should be specified as "values" (not "value")
       values = ["item1", "item2"]
@@ -108,10 +107,6 @@ locals {
     #    }
   }
 }
-
-################################################################################
-# SSM Parameter Module
-################################################################################
 
 module "multiple" {
   source = "../../"
@@ -153,31 +148,9 @@ module "multiple_ignore_value_changes" {
   tags = local.tags
 }
 
-module "explicit_region" {
-  source = "../../"
-
-  region = local.explicit_region
-  name   = "explicit-region"
-  value  = "test-value"
-
-  tags = local.tags
-}
-
-module "explicit_region_ignore_value_changes" {
-  source = "../../"
-
-  ignore_value_changes = true
-
-  region = local.explicit_region
-  name   = "explicit-region-ignore-value-changes"
-  value  = "test-value"
-
-  tags = local.tags
-}
-
-##########
+################################################################################
 # Wrapper
-##########
+################################################################################
 
 locals {
   parameters_for_wrapper = {
@@ -194,9 +167,9 @@ module "wrapper" {
   items = local.parameters_for_wrapper
 }
 
-###########
+################################################################################
 # Disabled
-###########
+################################################################################
 
 module "disabled" {
   source = "../../"

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,6 +1,6 @@
-#######################
+################################################################################
 # SSM Parameter values
-#######################
+################################################################################
 
 output "raw_value" {
   description = "Raw value of the parameter (as it is stored in SSM). Use 'value' output to get jsondecode'd value"
@@ -31,9 +31,9 @@ output "secure_type" {
   sensitive   = false
 }
 
-################
+################################################################################
 # SSM Parameter
-################
+################################################################################
 
 output "ssm_parameter_arn" {
   description = "The ARN of the parameter"
@@ -53,9 +53,4 @@ output "ssm_parameter_name" {
 output "ssm_parameter_type" {
   description = "Type of the parameter"
   value       = { for k, v in module.multiple : k => v.ssm_parameter_type }
-}
-
-output "ssm_parameter_tags_all" {
-  description = "All tags used for the parameter"
-  value       = { for k, v in module.multiple : k => v.ssm_parameter_tags_all }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.8"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.37"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,49 +9,59 @@ locals {
   value       = local.list_type ? (length(var.values) > 0 ? jsonencode(var.values) : var.value) : var.value
 }
 
+################################################################################
+# SSM Parameter
+################################################################################
+
 resource "aws_ssm_parameter" "this" {
   count = var.create && !var.ignore_value_changes ? 1 : 0
 
-  name        = var.name
-  type        = local.type
-  description = var.description
-  region      = var.region
+  region = var.region
 
-  value          = local.secure_type ? local.value : null
-  insecure_value = local.list_type || local.string_type ? local.value : null
-
-  tier            = var.tier
-  key_id          = local.secure_type ? var.key_id : null
-  allowed_pattern = var.allowed_pattern
-  data_type       = var.data_type
-
-  overwrite = var.overwrite
+  allowed_pattern  = var.allowed_pattern
+  data_type        = var.data_type
+  description      = var.description
+  insecure_value   = local.list_type || local.string_type ? local.value : null
+  key_id           = local.secure_type ? var.key_id : null
+  name             = var.name
+  overwrite        = var.overwrite
+  tier             = var.tier
+  type             = local.type
+  value_wo         = local.secure_type ? local.value : null
+  value_wo_version = local.secure_type ? coalesce(var.value_wo_version, 1) : null
 
   tags = var.tags
 }
 
+################################################################################
+# SSM Parameter - Ignore Value Changes
+################################################################################
+
 resource "aws_ssm_parameter" "ignore_value" {
   count = var.create && var.ignore_value_changes ? 1 : 0
 
-  name        = var.name
-  type        = local.type
-  description = var.description
-  region      = var.region
+  region = var.region
 
-  value          = local.secure_type ? local.value : null
-  insecure_value = local.list_type || local.string_type ? local.value : null
-
-  tier            = var.tier
-  key_id          = local.secure_type ? var.key_id : null
-  allowed_pattern = var.allowed_pattern
-  data_type       = var.data_type
+  allowed_pattern  = var.allowed_pattern
+  data_type        = var.data_type
+  description      = var.description
+  insecure_value   = local.list_type || local.string_type ? local.value : null
+  key_id           = local.secure_type ? var.key_id : null
+  name             = var.name
+  overwrite        = var.overwrite
+  tier             = var.tier
+  type             = local.type
+  value_wo         = local.secure_type ? local.value : null
+  value_wo_version = local.secure_type ? coalesce(var.value_wo_version, 1) : null
 
   tags = var.tags
 
   lifecycle {
     ignore_changes = [
       insecure_value,
-      value
+      value,
+      value_wo,
+      value_wo_version,
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "aws_ssm_parameter" "this" {
   name        = var.name
   type        = local.type
   description = var.description
+  region      = var.region
 
   value          = local.secure_type ? local.value : null
   insecure_value = local.list_type || local.string_type ? local.value : null
@@ -35,6 +36,7 @@ resource "aws_ssm_parameter" "ignore_value" {
   name        = var.name
   type        = local.type
   description = var.description
+  region      = var.region
 
   value          = local.secure_type ? local.value : null
   insecure_value = local.list_type || local.string_type ? local.value : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-#######################
+################################################################################
 # SSM Parameter values
-#######################
+################################################################################
 
 locals {
   # Making values nonsensitive, but keeping them in separate locals
@@ -44,9 +44,9 @@ output "secure_type" {
   value       = local.secure_type
 }
 
-################
+################################################################################
 # SSM Parameter
-################
+################################################################################
 
 output "ssm_parameter_arn" {
   description = "The ARN of the parameter"
@@ -66,9 +66,4 @@ output "ssm_parameter_name" {
 output "ssm_parameter_type" {
   description = "Type of the parameter"
   value       = try(aws_ssm_parameter.this[0].type, aws_ssm_parameter.ignore_value[0].type, null)
-}
-
-output "ssm_parameter_tags_all" {
-  description = "All tags used for the parameter"
-  value       = try(aws_ssm_parameter.this[0].tags_all, aws_ssm_parameter.ignore_value[0].tags_all, null)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "secure_type" {
   default     = false
 }
 
+variable "region" {
+  description = "Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # SSM Parameter
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create" {
   default     = true
 }
 
+variable "region" {
+  description = "Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 variable "ignore_value_changes" {
   description = "Whether to create SSM Parameter and ignore changes in value"
   type        = bool
@@ -11,23 +17,59 @@ variable "ignore_value_changes" {
 }
 
 variable "secure_type" {
-  description = "Whether the type of the value should be considered as secure or not?"
+  description = "Whether the type of the value should be considered as secure or not"
   type        = bool
   default     = false
-}
-
-variable "region" {
-  description = "Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration"
-  type        = string
-  default     = null
 }
 
 ################################################################################
 # SSM Parameter
 ################################################################################
 
+variable "allowed_pattern" {
+  description = "Regular expression used to validate the parameter value"
+  type        = string
+  default     = null
+}
+
+variable "data_type" {
+  description = "Data type of the parameter. Valid values: `text`, `aws:ssm:integration` and `aws:ec2:image` for AMI format, see the [Native parameter support for Amazon Machine Image IDs](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-ec2-aliases.html)"
+  type        = string
+  default     = null
+}
+
+variable "description" {
+  description = "Description of the parameter"
+  type        = string
+  default     = null
+}
+
+variable "key_id" {
+  description = "KMS key ID or ARN for encrypting a `SecureString`"
+  type        = string
+  default     = null
+}
+
 variable "name" {
-  description = "Name of SSM parameter"
+  description = "Name of the parameter. If the name contains a path (e.g., any forward slashes (`/`)), it must be fully qualified with a leading forward slash (`/`)"
+  type        = string
+  default     = null
+}
+
+variable "overwrite" {
+  description = "Overwrite an existing parameter. If not specified, defaults to `false` during create operations to avoid overwriting existing resources and then `true` for all subsequent operations once the resource is managed by Terraform"
+  type        = bool
+  default     = false
+}
+
+variable "tier" {
+  description = "Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are Standard, Advanced, and Intelligent-Tiering. Downgrading an Advanced tier parameter to Standard will recreate the resource"
+  type        = string
+  default     = null
+}
+
+variable "type" {
+  description = "Type of the parameter. Valid types are `String`, `StringList` and `SecureString`"
   type        = string
   default     = null
 }
@@ -44,50 +86,14 @@ variable "values" {
   default     = []
 }
 
-variable "description" {
-  description = "Description of the parameter"
-  type        = string
-  default     = null
-}
-
-variable "type" {
-  description = "Type of the parameter. Valid types are String, StringList and SecureString."
-  type        = string
-  default     = null
-}
-
-variable "tier" {
-  description = "Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are Standard, Advanced, and Intelligent-Tiering. Downgrading an Advanced tier parameter to Standard will recreate the resource."
-  type        = string
-  default     = null
-}
-
-variable "key_id" {
-  description = "KMS key ID or ARN for encrypting a parameter (when type is SecureString)"
-  type        = string
-  default     = null
-}
-
-variable "allowed_pattern" {
-  description = "Regular expression used to validate the parameter value."
-  type        = string
-  default     = null
-}
-
-variable "data_type" {
-  description = "Data type of the parameter. Valid values: text, aws:ssm:integration and aws:ec2:image for AMI format."
-  type        = string
+variable "value_wo_version" {
+  description = "Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of type. Additionally, write-only values are never stored to state. `value_wo_version` can be used to trigger an update and is required with this argument"
+  type        = number
   default     = null
 }
 
 variable "tags" {
-  description = "A mapping of tags to assign to resources"
+  description = "A map of tags to add to all resources"
   type        = map(string)
   default     = {}
-}
-
-variable "overwrite" {
-  description = "Overwrite an existing parameter. If not specified, defaults to false during create operations to avoid overwriting existing resources and then true for all subsequent operations once the resource is managed by Terraform. Only relevant if ignore_value_changes is false."
-  type        = bool
-  default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.8"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.37"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -17,5 +17,6 @@ module "wrapper" {
   tier                 = try(each.value.tier, var.defaults.tier, null)
   type                 = try(each.value.type, var.defaults.type, null)
   value                = try(each.value.value, var.defaults.value, null)
+  value_wo_version     = try(each.value.value_wo_version, var.defaults.value_wo_version, null)
   values               = try(each.value.values, var.defaults.values, [])
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -11,6 +11,7 @@ module "wrapper" {
   key_id               = try(each.value.key_id, var.defaults.key_id, null)
   name                 = try(each.value.name, var.defaults.name, null)
   overwrite            = try(each.value.overwrite, var.defaults.overwrite, false)
+  region               = try(each.value.region, var.defaults.region, null)
   secure_type          = try(each.value.secure_type, var.defaults.secure_type, false)
   tags                 = try(each.value.tags, var.defaults.tags, {})
   tier                 = try(each.value.tier, var.defaults.tier, null)

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0"
+      version = ">= 6.8"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.37"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## Description
- Terraform `v1.11` is now minimum supported version to support the write-only (`wo_*` ) arguments
- AWS provider `v6.8` is now minimum supported version
- The `value` argument has been replaced with the `value_wo` to ensure the sensitive value is never written to state
- `value_wo_version` has been added to support the use of `value_wo`
- `ssm_parameter_tags_all` output has been removed
- Support for `region` parameter to specify the AWS region for the resources created if different from the provider region.

## Motivation and Context
- Resolves #13

## Breaking Changes
- Yes

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
