### PR TITLE
fix: Set default value for `overwrite` to `null` which by default is `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ No modules.
 | <a name="input_ignore_value_changes"></a> [ignore\_value\_changes](#input\_ignore\_value\_changes) | Whether to create SSM Parameter and ignore changes in value | `bool` | `false` | no |
 | <a name="input_key_id"></a> [key\_id](#input\_key\_id) | KMS key ID or ARN for encrypting a `SecureString` | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the parameter. If the name contains a path (e.g., any forward slashes (`/`)), it must be fully qualified with a leading forward slash (`/`) | `string` | `null` | no |
-| <a name="input_overwrite"></a> [overwrite](#input\_overwrite) | Overwrite an existing parameter. If not specified, defaults to `false` during create operations to avoid overwriting existing resources and then `true` for all subsequent operations once the resource is managed by Terraform | `bool` | `false` | no |
+| <a name="input_overwrite"></a> [overwrite](#input\_overwrite) | Overwrite an existing parameter. If not specified, defaults to `false` during create operations to avoid overwriting existing resources and then `true` for all subsequent operations once the resource is managed by Terraform | `bool` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the Region set in the provider configuration | `string` | `null` | no |
 | <a name="input_secure_type"></a> [secure\_type](#input\_secure\_type) | Whether the type of the value should be considered as secure or not | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "name" {
 variable "overwrite" {
   description = "Overwrite an existing parameter. If not specified, defaults to `false` during create operations to avoid overwriting existing resources and then `true` for all subsequent operations once the resource is managed by Terraform"
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "tier" {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -10,7 +10,7 @@ module "wrapper" {
   ignore_value_changes = try(each.value.ignore_value_changes, var.defaults.ignore_value_changes, false)
   key_id               = try(each.value.key_id, var.defaults.key_id, null)
   name                 = try(each.value.name, var.defaults.name, null)
-  overwrite            = try(each.value.overwrite, var.defaults.overwrite, false)
+  overwrite            = try(each.value.overwrite, var.defaults.overwrite, null)
   region               = try(each.value.region, var.defaults.region, null)
   secure_type          = try(each.value.secure_type, var.defaults.secure_type, false)
   tags                 = try(each.value.tags, var.defaults.tags, {})


### PR DESCRIPTION
## Description
Fixing correct default for `overwrite` per https://github.com/terraform-aws-modules/terraform-aws-ssm-parameter/pull/11#issuecomment-3515737380

I've also made a fix against the `v1.2.0` tag in its own branch should the module owners want to create a `v1.2.1` from that as well: https://github.com/terraform-aws-modules/terraform-aws-ssm-parameter/compare/v1.2.0...rockholla:terraform-aws-ssm-parameter:fix-v1.2/overwrite-param-default-null

## Motivation and Context
Just adjusting to more-accurately expose the default behavior of the `aws_ssm_parameter` resource: `false` overwrite on initial creation, `true` thereafter, whereas prior to this change, it would be `false` thereafter as a default.

## Breaking Changes
No, fixing forward

## How Has This Been Tested?
The existing tests should still cover this I believe. I will let the module owners decide if additional tests are needed, and happy to continue to help there.

Along w/ running `examples/complete` as a validation, I've done some manual apply validation on the current version vs this version and verified things like initial creation/subsequent behavior on applies for overwriting vs not/respecting provider resource default, e.g. the `null` value explicitly set on the resource does what we expect, and it does.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
