### PR TITLE
feat: Add provider meta user-agent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.104.0
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.103.0
+    rev: v1.104.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ module "parameter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.8 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ module "parameter" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.8 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.27 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.28 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.27 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.28 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.8"
+      version = ">= 6.27"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.8"
+      version = ">= 6.27"
     }
+  }
+
+  provider_meta "aws" {
+    user_agent = [
+      "github.com/terraform-aws-modules"
+    ]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 
   provider_meta "aws" {
     user_agent = [
-      "github.com/terraform-aws-modules"
+      "github.com/terraform-aws-modules/terraform-aws-ssm-parameter"
     ]
   }
 }

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -70,9 +70,9 @@ module "wrapper" {
 
 ```hcl
 terraform {
-  source = "tfr:///terraform-aws-modules/s3-bucket/aws//wrappers"
+  source = "tfr:///terraform-aws-modules/ssm-parameter/aws//wrappers"
   # Alternative source:
-  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git//wrappers?ref=master"
+  # source = "git::git@github.com:terraform-aws-modules/terraform-aws-ssm-parameter.git//wrappers?ref=master"
 }
 
 inputs = {

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.8"
+      version = ">= 6.27"
     }
+  }
+
+  provider_meta "aws" {
+    user_agent = [
+      "github.com/terraform-aws-modules"
+    ]
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,13 +4,13 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.27"
+      version = ">= 6.28"
     }
   }
 
   provider_meta "aws" {
     user_agent = [
-      "github.com/terraform-aws-modules"
+      "github.com/terraform-aws-modules/terraform-aws-ssm-parameter"
     ]
   }
 }


### PR DESCRIPTION
## Description
- Add provider meta user-agent, replacing static tag

## Motivation and Context
- Attribution to our modules can now be collected through normal means by adding to the user-agent used in API requests https://github.com/hashicorp/terraform-provider-aws/pull/45464 - we no longer need the static tags

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
