### PR TITLE
fix: INFRA-13689 handle aws provider v6 populating `value` for non-SecureString p…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -12,7 +12,11 @@ locals {
     try(aws_ssm_parameter.this[0].insecure_value, null),
     try(aws_ssm_parameter.ignore_value[0].insecure_value, null),
   ]))
-  raw_value = one(compact([local.stored_value, local.stored_insecure_value]))
+  # AWS provider v6 populates `value` for non-SecureString params too, so
+  # `stored_value` and `stored_insecure_value` are both set for String/StringList
+  # types. Pick by `secure_type` instead of `compact` to avoid the
+  # `one(list with 2 elements)` failure.
+  raw_value = local.secure_type ? local.stored_value : local.stored_insecure_value
 }
 
 output "raw_value" {


### PR DESCRIPTION
…arams

With AWS provider v6, reading back an `aws_ssm_parameter` of type `String` or `StringList` populates both `value` (computed from the API) and `insecure_value` (from config). The previous
`one(compact([stored_value, stored_insecure_value]))` then sees two non-empty elements and fails with `Invalid value for "list" parameter: must be ... zero or one elements`.

Pick the source by `secure_type` instead, which preserves the pre-v6 intent: secure read for `SecureString`, insecure read for everything else.
